### PR TITLE
Removed the mandatory requirement to include `stamped_headers` key when implementing `on_signature()`

### DIFF
--- a/celery/app/control.py
+++ b/celery/app/control.py
@@ -499,6 +499,41 @@ class Control:
             'signal': signal,
         }, **kwargs)
 
+    def revoke_by_stamped_headers(self, headers, destination=None, terminate=False,
+                                  signal=TERM_SIGNAME, **kwargs):
+        """
+        Tell all (or specific) workers to revoke a task by headers.
+
+        If a task is revoked, the workers will ignore the task and
+        not execute it after all.
+
+        Arguments:
+            headers (dict[str, Union(str, list)]): Headers to match when revoking tasks.
+            terminate (bool): Also terminate the process currently working
+                on the task (if any).
+            signal (str): Name of signal to send to process if terminate.
+                Default is TERM.
+
+        See Also:
+            :meth:`broadcast` for supported keyword arguments.
+        """
+        result = self.broadcast('revoke_by_stamped_headers', destination=destination, arguments={
+            'headers': headers,
+            'terminate': terminate,
+            'signal': signal,
+        }, **kwargs)
+
+        task_ids = set()
+        if result:
+            for host in result:
+                for response in host.values():
+                    task_ids.update(response['ok'])
+
+        if task_ids:
+            return self.revoke(list(task_ids), destination=destination, terminate=terminate, signal=signal, **kwargs)
+        else:
+            return result
+
     def terminate(self, task_id,
                   destination=None, signal=TERM_SIGNAME, **kwargs):
         """Tell all (or specific) workers to terminate a task by id (or list of ids).

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -501,7 +501,10 @@ class Signature(dict):
         """
         headers = headers.copy()
         if visitor is not None:
-            headers.update(visitor.on_signature(self, **headers))
+            visitor_headers = visitor.on_signature(self, **headers)
+            if "stamped_headers" not in visitor_headers:
+                visitor_headers["stamped_headers"] = list(visitor_headers.keys())
+            headers.update(visitor_headers)
         else:
             headers["stamped_headers"] = [header for header in headers.keys() if header not in self.options]
             _merge_dictionaries(headers, self.options)

--- a/celery/result.py
+++ b/celery/result.py
@@ -161,6 +161,30 @@ class AsyncResult(ResultBase):
                                 terminate=terminate, signal=signal,
                                 reply=wait, timeout=timeout)
 
+    def revoke_by_stamped_headers(self, headers, connection=None, terminate=False, signal=None,
+                                  wait=False, timeout=None):
+        """Send revoke signal to all workers only for tasks with matching headers values.
+
+        Any worker receiving the task, or having reserved the
+        task, *must* ignore it.
+        All header fields *must* match.
+
+        Arguments:
+            headers (dict[str, Union(str, list)]): Headers to match when revoking tasks.
+            terminate (bool): Also terminate the process currently working
+                on the task (if any).
+            signal (str): Name of signal to send to process if terminate.
+                Default is TERM.
+            wait (bool): Wait for replies from workers.
+                The ``timeout`` argument specifies the seconds to wait.
+                Disabled by default.
+            timeout (float): Time in seconds to wait for replies when
+                ``wait`` is enabled.
+        """
+        self.app.control.revoke_by_stamped_headers(headers, connection=connection,
+                                                   terminate=terminate, signal=signal,
+                                                   reply=wait, timeout=timeout)
+
     def get(self, timeout=None, propagate=True, interval=0.5,
             no_ack=True, follow_parents=True, callback=None, on_message=None,
             on_interval=None, disable_sync_subtasks=True,

--- a/celery/worker/control.py
+++ b/celery/worker/control.py
@@ -1,12 +1,13 @@
 """Worker remote control command implementations."""
 import io
 import tempfile
+import warnings
 from collections import UserDict, namedtuple
 
 from billiard.common import TERM_SIGNAME
 from kombu.utils.encoding import safe_repr
 
-from celery.exceptions import WorkerShutdown
+from celery.exceptions import CeleryWarning, WorkerShutdown
 from celery.platforms import signals as _signals
 from celery.utils.functional import maybe_list
 from celery.utils.log import get_logger
@@ -146,6 +147,60 @@ def revoke(state, task_id, terminate=False, signal=None, **kwargs):
     #     Outside of this scope that is a function.
     # supports list argument since 3.1
     task_ids, task_id = set(maybe_list(task_id) or []), None
+    task_ids = _revoke(state, task_ids, terminate, signal, **kwargs)
+    return ok(f'tasks {task_ids} flagged as revoked')
+
+
+@control_command(
+    variadic='headers',
+    signature='[key1=value1 [key2=value2 [... [keyN=valueN]]]]',
+)
+def revoke_by_stamped_headers(state, headers, terminate=False, signal=None, **kwargs):
+    """Revoke task by header (or list of headers).
+
+    Keyword Arguments:
+        terminate (bool): Also terminate the process if the task is active.
+        signal (str): Name of signal to use for terminate (e.g., ``KILL``).
+    """
+    # pylint: disable=redefined-outer-name
+    # XXX Note that this redefines `terminate`:
+    #     Outside of this scope that is a function.
+    # supports list argument since 3.1
+    if isinstance(headers, list):
+        headers = {h.split('=')[0]: h.split('=')[1] for h in headers}, None
+
+    worker_state.revoked_headers.update(headers)
+
+    if not terminate:
+        return ok(f'headers {headers} flagged as revoked')
+
+    task_ids = set()
+    requests = list(worker_state.active_requests)
+
+    # Terminate all running tasks of matching headers
+    if requests:
+        warnings.warn(
+            "Terminating tasks by headers does not scale well when worker concurrency is high",
+            CeleryWarning
+        )
+
+        for req in requests:
+            if req.stamped_headers:
+                for stamped_header_key, expected_header_value in headers.items():
+                    if stamped_header_key in req.stamped_headers and \
+                            stamped_header_key in req._message.headers['stamps']:
+                        actual_header = req._message.headers['stamps'][stamped_header_key]
+                        if expected_header_value in actual_header:
+                            task_ids.add(req.task_id)
+                            continue
+
+    task_ids = _revoke(state, task_ids, terminate, signal, **kwargs)
+    if isinstance(task_ids, dict):
+        return task_ids
+    return ok(list(task_ids))
+
+
+def _revoke(state, task_ids, terminate=False, signal=None, **kwargs):
     size = len(task_ids)
     terminated = set()
 
@@ -166,7 +221,7 @@ def revoke(state, task_id, terminate=False, signal=None, **kwargs):
 
     idstr = ', '.join(task_ids)
     logger.info('Tasks flagged as revoked: %s', idstr)
-    return ok(f'tasks {idstr} flagged as revoked')
+    return task_ids
 
 
 @control_command(

--- a/celery/worker/state.py
+++ b/celery/worker/state.py
@@ -67,6 +67,9 @@ all_total_count = [0]
 #: the list of currently revoked tasks.  Persistent if ``statedb`` set.
 revoked = LimitedSet(maxlen=REVOKES_MAX, expires=REVOKE_EXPIRES)
 
+#: Mapping of stamped headers flagged for revoking.
+revoked_headers = {}
+
 should_stop = None
 should_terminate = None
 
@@ -79,6 +82,7 @@ def reset_state():
     total_count.clear()
     all_total_count[:] = [0]
     revoked.clear()
+    revoked_headers.clear()
 
 
 def maybe_shutdown():

--- a/docs/userguide/canvas.rst
+++ b/docs/userguide/canvas.rst
@@ -1232,9 +1232,22 @@ the external monitoring system.
 
     class MonitoringIdStampingVisitor(StampingVisitor):
         def on_signature(self, sig, **headers) -> dict:
-            return {'monitoring_id': uuid4(), 'stamped_headers': ['monitoring_id']}
+            return {'monitoring_id': uuid4().hex}
 
-Next, lets see how to use the ``MonitoringIdStampingVisitor`` stamping visitor.
+.. note::
+
+    The ``stamped_headers`` key returned in ``on_signature`` is used to specify the headers that will be
+    stamped on the task. If this key is not specified, the stamping visitor will assume all keys in the
+    returned dictionary are the stamped headers from the visitor.
+    This means the following code block will result in the same behavior as the previous example.
+
+.. code-block:: python
+
+    class MonitoringIdStampingVisitor(StampingVisitor):
+        def on_signature(self, sig, **headers) -> dict:
+            return {'monitoring_id': uuid4().hex, 'stamped_headers': ['monitoring_id']}
+
+Next, lets see how to use the ``MonitoringIdStampingVisitor`` example stamping visitor.
 
 .. code-block:: python
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -3,6 +3,7 @@ pytest-celery==0.0.0
 pytest-subtests==0.8.0
 pytest-timeout~=2.1.0
 pytest-click==1.1.0
+pytest-order==1.0.1
 boto3>=1.9.178
 moto>=2.2.6
 # typing extensions

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -1,10 +1,13 @@
 from datetime import datetime, timedelta
 from time import perf_counter, sleep
+from uuid import uuid4
 
 import pytest
 
 import celery
-from celery import group
+from celery import chain, chord, group
+from celery.canvas import StampingVisitor
+from celery.worker import state as worker_state
 
 from .conftest import get_active_redis_channels
 from .tasks import (ClassBasedAutoRetryTask, ExpectedException, add, add_ignore_result, add_not_typed, fail,
@@ -194,6 +197,87 @@ class test_tasks:
         assert result.ready() is True
         assert result.failed() is False
         assert result.successful() is False
+
+    def test_revoked_by_headers_simple_canvas(self, manager):
+        """Testing revoking of task using a stamped header"""
+        target_monitoring_id = uuid4().hex
+
+        class MonitoringIdStampingVisitor(StampingVisitor):
+            def on_signature(self, sig, **headers) -> dict:
+                return {'monitoring_id': target_monitoring_id, 'stamped_headers': ['monitoring_id']}
+
+        for monitoring_id in [target_monitoring_id, uuid4().hex, 4242, None]:
+            stamped_task = add.si(1, 1)
+            stamped_task.stamp(visitor=MonitoringIdStampingVisitor())
+            result = stamped_task.freeze()
+            result.revoke_by_stamped_headers(headers={'monitoring_id': [monitoring_id]})
+            stamped_task.apply_async()
+            if monitoring_id == target_monitoring_id:
+                with pytest.raises(celery.exceptions.TaskRevokedError):
+                    result.get()
+                assert result.status == 'REVOKED'
+                assert result.ready() is True
+                assert result.failed() is False
+                assert result.successful() is False
+            else:
+                assert result.get() == 2
+                assert result.status == 'SUCCESS'
+                assert result.ready() is True
+                assert result.failed() is False
+                assert result.successful() is True
+        worker_state.revoked_headers.clear()
+
+    # This test leaves the environment dirty,
+    # so we let it run last in the suite to avoid
+    # affecting other tests until we can fix it.
+    @pytest.mark.order("last")
+    @pytest.mark.parametrize('monitoring_id', [
+        "4242",
+        [1234, uuid4().hex],
+    ])
+    def test_revoked_by_headers_complex_canvas(self, manager, subtests, monitoring_id):
+        """Testing revoking of task using a stamped header"""
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
+        target_monitoring_id = isinstance(monitoring_id, list) and monitoring_id[0] or monitoring_id
+
+        class MonitoringIdStampingVisitor(StampingVisitor):
+            def on_signature(self, sig, **headers) -> dict:
+                return {'monitoring_id': target_monitoring_id, 'stamped_headers': ['monitoring_id']}
+
+        stamped_task = sleeping.si(4)
+        stamped_task.stamp(visitor=MonitoringIdStampingVisitor())
+        result = stamped_task.freeze()
+
+        canvas = [
+            group([stamped_task]),
+            chord(group([stamped_task]), sleeping.si(2)),
+            chord(group([sleeping.si(2)]), stamped_task),
+            chain(stamped_task),
+            group([sleeping.si(2), stamped_task, sleeping.si(2)]),
+            chord([sleeping.si(2), stamped_task], sleeping.si(2)),
+            chord([sleeping.si(2), sleeping.si(2)], stamped_task),
+            chain(sleeping.si(2), stamped_task),
+            chain(sleeping.si(2), group([sleeping.si(2), stamped_task, sleeping.si(2)])),
+            chain(sleeping.si(2), group([sleeping.si(2), stamped_task]), sleeping.si(2)),
+            chain(sleeping.si(2), group([sleeping.si(2), sleeping.si(2)]), stamped_task),
+        ]
+
+        result.revoke_by_stamped_headers(headers={'monitoring_id': monitoring_id})
+
+        for sig in canvas:
+            sig_result = sig.apply_async()
+            with subtests.test(msg='Testing if task was revoked'):
+                with pytest.raises(celery.exceptions.TaskRevokedError):
+                    sig_result.get()
+                assert result.status == 'REVOKED'
+                assert result.ready() is True
+                assert result.failed() is False
+                assert result.successful() is False
+        worker_state.revoked_headers.clear()
 
     @flaky
     def test_wrong_arguments(self, manager):

--- a/t/integration/test_tasks.py
+++ b/t/integration/test_tasks.py
@@ -204,7 +204,7 @@ class test_tasks:
 
         class MonitoringIdStampingVisitor(StampingVisitor):
             def on_signature(self, sig, **headers) -> dict:
-                return {'monitoring_id': target_monitoring_id, 'stamped_headers': ['monitoring_id']}
+                return {'monitoring_id': target_monitoring_id}
 
         for monitoring_id in [target_monitoring_id, uuid4().hex, 4242, None]:
             stamped_task = add.si(1, 1)

--- a/t/unit/app/test_control.py
+++ b/t/unit/app/test_control.py
@@ -424,6 +424,16 @@ class test_Control:
             terminate=False,
         )
 
+    def test_revoke_by_stamped_headers(self):
+        self.app.control.revoke_by_stamped_headers({'foo': 'bar'})
+        self.assert_control_called_with_args(
+            'revoke_by_stamped_headers',
+            destination=None,
+            headers={'foo': 'bar'},
+            signal=control.TERM_SIGNAME,
+            terminate=False,
+        )
+
     def test_revoke__with_options(self):
         self.app.control.revoke(
             'foozbaaz',
@@ -436,6 +446,23 @@ class test_Control:
             'revoke',
             destination='a@q.com',
             task_id='foozbaaz',
+            signal='KILL',
+            terminate=True,
+            _options={'limit': 404},
+        )
+
+    def test_revoke_by_stamped_headers__with_options(self):
+        self.app.control.revoke_by_stamped_headers(
+            {'foo': 'bar'},
+            destination='a@q.com',
+            terminate=True,
+            signal='KILL',
+            limit=404,
+        )
+        self.assert_control_called_with_args(
+            'revoke_by_stamped_headers',
+            destination='a@q.com',
+            headers={'foo': 'bar'},
             signal='KILL',
             terminate=True,
             _options={'limit': 404},
@@ -496,6 +523,14 @@ class test_Control:
         self.app.AsyncResult('foozbazzbar').revoke()
         self.app.control.revoke.assert_called_with(
             'foozbazzbar',
+            connection=None, reply=False, signal=None,
+            terminate=False, timeout=None)
+
+    def test_revoke_by_stamped_headers_from_result(self):
+        self.app.control.revoke_by_stamped_headers = Mock(name='revoke_by_stamped_headers')
+        self.app.AsyncResult('foozbazzbar').revoke_by_stamped_headers({'foo': 'bar'})
+        self.app.control.revoke_by_stamped_headers.assert_called_with(
+            {'foo': 'bar'},
             connection=None, reply=False, signal=None,
             terminate=False, timeout=None)
 

--- a/t/unit/worker/test_control.py
+++ b/t/unit/worker/test_control.py
@@ -17,7 +17,7 @@ from celery.worker import consumer, control
 from celery.worker import state as worker_state
 from celery.worker.pidbox import Pidbox, gPidbox
 from celery.worker.request import Request
-from celery.worker.state import REVOKE_EXPIRES, revoked
+from celery.worker.state import REVOKE_EXPIRES, revoked, revoked_headers
 
 hostname = socket.gethostname()
 
@@ -540,6 +540,24 @@ class test_ControlPanel:
             assert 'terminate:' in r['ok']
             # unknown task id only revokes
             r = control.revoke(state, uuid(), terminate=True)
+            assert 'tasks unknown' in r['ok']
+        finally:
+            worker_state.task_ready(request)
+
+    def test_revoke_by_stamped_headers_terminate(self):
+        request = Mock()
+        request.id = uuid()
+        request.options = stamped_header = {'stamp': 'foo'}
+        request.options['stamped_headers'] = ['stamp']
+        state = self.create_state()
+        state.consumer = Mock()
+        worker_state.task_reserved(request)
+        try:
+            r = control.revoke_by_stamped_headers(state, stamped_header, terminate=True)
+            assert stamped_header == revoked_headers
+            assert 'terminate:' in r['ok']
+            # unknown task id only revokes
+            r = control.revoke_by_stamped_headers(state, stamped_header, terminate=True)
             assert 'tasks unknown' in r['ok']
         finally:
             worker_state.task_ready(request)

--- a/t/unit/worker/test_state.py
+++ b/t/unit/worker/test_state.py
@@ -19,6 +19,7 @@ def reset_state():
     yield
     state.active_requests.clear()
     state.revoked.clear()
+    state.revoked_headers.clear()
     state.total_count.clear()
 
 


### PR DESCRIPTION
The `Signature.stamp()` method will now implicitly populate the "stamping_header" key if it was not manually set.